### PR TITLE
feat(subscription): add secondary mapping for provider

### DIFF
--- a/x/subscription/keeper/query_subscription.go
+++ b/x/subscription/keeper/query_subscription.go
@@ -33,7 +33,7 @@ func (k Keeper) Subscriptions(goCtx context.Context, req *types.QuerySubscriptio
 	}
 	ctx := sdk.UnwrapSDKContext(goCtx)
 	storeAdapter := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
-	store := prefix.NewStore(storeAdapter, types.KeyPrefix(types.SubscriptionKeyPrefix))
+	store := prefix.NewStore(storeAdapter, types.KeyPrefix(types.ProviderSubscriptionKeyPrefix+"/"+req.Provider))
 
 	var subscriptions []types.Subscription
 	pageRes, err := query.Paginate(store, req.Pagination, func(key []byte, value []byte) error {

--- a/x/subscription/keeper/query_subscription.go
+++ b/x/subscription/keeper/query_subscription.go
@@ -42,9 +42,7 @@ func (k Keeper) Subscriptions(goCtx context.Context, req *types.QuerySubscriptio
 			return err
 		}
 
-		if subscription.Provider == req.Provider {
-			subscriptions = append(subscriptions, subscription)
-		}
+		subscriptions = append(subscriptions, subscription)
 		return nil
 	})
 	if err != nil {

--- a/x/subscription/keeper/query_subscription.go
+++ b/x/subscription/keeper/query_subscription.go
@@ -33,7 +33,7 @@ func (k Keeper) Subscriptions(goCtx context.Context, req *types.QuerySubscriptio
 	}
 	ctx := sdk.UnwrapSDKContext(goCtx)
 	storeAdapter := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
-	store := prefix.NewStore(storeAdapter, types.KeyPrefix(types.ProviderSubscriptionKeyPrefix+"/"+req.Provider))
+	store := prefix.NewStore(storeAdapter, types.KeyPrefix(types.SubscriptionProviderKeyPrefix+"/"+req.Provider))
 
 	var subscriptions []types.Subscription
 	pageRes, err := query.Paginate(store, req.Pagination, func(key []byte, value []byte) error {

--- a/x/subscription/keeper/query_subscription.go
+++ b/x/subscription/keeper/query_subscription.go
@@ -33,7 +33,7 @@ func (k Keeper) Subscriptions(goCtx context.Context, req *types.QuerySubscriptio
 	}
 	ctx := sdk.UnwrapSDKContext(goCtx)
 	storeAdapter := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
-	store := prefix.NewStore(storeAdapter, types.KeyProviderStore(req.Provider))
+	store := prefix.NewStore(storeAdapter, types.GetProviderStoreKey(req.Provider))
 
 	var subscriptions []types.Subscription
 	pageRes, err := query.Paginate(store, req.Pagination, func(key []byte, value []byte) error {

--- a/x/subscription/keeper/query_subscription.go
+++ b/x/subscription/keeper/query_subscription.go
@@ -33,7 +33,7 @@ func (k Keeper) Subscriptions(goCtx context.Context, req *types.QuerySubscriptio
 	}
 	ctx := sdk.UnwrapSDKContext(goCtx)
 	storeAdapter := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
-	store := prefix.NewStore(storeAdapter, types.KeyPrefix(types.SubscriptionProviderKeyPrefix+"/"+req.Provider))
+	store := prefix.NewStore(storeAdapter, types.KeyProviderStore(req.Provider))
 
 	var subscriptions []types.Subscription
 	pageRes, err := query.Paginate(store, req.Pagination, func(key []byte, value []byte) error {

--- a/x/subscription/keeper/subscription.go
+++ b/x/subscription/keeper/subscription.go
@@ -15,7 +15,7 @@ func (k Keeper) SetSubscription(ctx sdk.Context, subscription types.Subscription
 	appendedValue := k.cdc.MustMarshal(&subscription)
 	store.Set([]byte(subscription.Id), appendedValue)
 
-	providerStore := prefix.NewStore(storeAdapter, types.KeyPrefix(types.ProviderSubscriptionKeyPrefix+"/"+subscription.Provider))
+	providerStore := prefix.NewStore(storeAdapter, types.KeyPrefix(types.SubscriptionProviderKeyPrefix+"/"+subscription.Provider))
 	providerStore.Set([]byte(subscription.Id), appendedValue)
 }
 

--- a/x/subscription/keeper/subscription.go
+++ b/x/subscription/keeper/subscription.go
@@ -15,7 +15,7 @@ func (k Keeper) SetSubscription(ctx sdk.Context, subscription types.Subscription
 	appendedValue := k.cdc.MustMarshal(&subscription)
 	store.Set([]byte(subscription.Id), appendedValue)
 
-	providerStore := prefix.NewStore(storeAdapter, types.KeyProviderStore(subscription.Provider))
+	providerStore := prefix.NewStore(storeAdapter, types.GetProviderStoreKey(subscription.Provider))
 	providerStore.Set([]byte(subscription.Id), appendedValue)
 }
 

--- a/x/subscription/keeper/subscription.go
+++ b/x/subscription/keeper/subscription.go
@@ -14,6 +14,9 @@ func (k Keeper) SetSubscription(ctx sdk.Context, subscription types.Subscription
 
 	appendedValue := k.cdc.MustMarshal(&subscription)
 	store.Set([]byte(subscription.Id), appendedValue)
+
+	providerStore := prefix.NewStore(storeAdapter, types.KeyPrefix(types.ProviderSubscriptionKeyPrefix+"/"+subscription.Provider))
+	providerStore.Set([]byte(subscription.Id), appendedValue)
 }
 
 func (k Keeper) GetSubscription(ctx sdk.Context, subscriptionId string) (subscription types.Subscription, found bool) {

--- a/x/subscription/keeper/subscription.go
+++ b/x/subscription/keeper/subscription.go
@@ -15,7 +15,7 @@ func (k Keeper) SetSubscription(ctx sdk.Context, subscription types.Subscription
 	appendedValue := k.cdc.MustMarshal(&subscription)
 	store.Set([]byte(subscription.Id), appendedValue)
 
-	providerStore := prefix.NewStore(storeAdapter, types.KeyPrefix(types.SubscriptionProviderKeyPrefix+"/"+subscription.Provider))
+	providerStore := prefix.NewStore(storeAdapter, types.KeyProviderStore(subscription.Provider))
 	providerStore.Set([]byte(subscription.Id), appendedValue)
 }
 

--- a/x/subscription/keeper/subscription_test.go
+++ b/x/subscription/keeper/subscription_test.go
@@ -1,0 +1,54 @@
+package keeper_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"topchain/x/subscription/types"
+
+	keepertest "topchain/testutil/keeper"
+)
+
+func TestSubscription(t *testing.T) {
+	keeper, ctx := keepertest.SubscriptionKeeper(t)
+	subscription := types.Subscription{
+		Id:       "sub1",
+		Provider: "provider1",
+	}
+
+	keeper.SetSubscription(ctx, subscription)
+
+	req := &types.QuerySubscriptionRequest{Id: "sub1"}
+
+	retrievedSubscription, err := keeper.Subscription(ctx, req)
+	require.NoError(t, err)
+	require.Equal(t, subscription, retrievedSubscription.Subscription)
+}
+
+func TestSubscriptions(t *testing.T) {
+	keeper, ctx := keepertest.SubscriptionKeeper(t)
+	subscription1 := types.Subscription{
+		Id:       "sub1",
+		Provider: "provider1",
+	}
+	subscription2 := types.Subscription{
+		Id:       "sub2",
+		Provider: "provider1",
+	}
+	subscription3 := types.Subscription{
+		Id:       "sub3",
+		Provider: "provider2",
+	}
+
+	keeper.SetSubscription(ctx, subscription1)
+	keeper.SetSubscription(ctx, subscription2)
+	keeper.SetSubscription(ctx, subscription3)
+
+	req := &types.QuerySubscriptionsRequest{Provider: "provider1"}
+	res, err := keeper.Subscriptions(ctx, req)
+	require.NoError(t, err)
+	require.Len(t, res.Subscriptions, 2)
+	require.Contains(t, res.Subscriptions, subscription1)
+	require.Contains(t, res.Subscriptions, subscription2)
+}

--- a/x/subscription/keeper/subscription_test.go
+++ b/x/subscription/keeper/subscription_test.go
@@ -7,6 +7,8 @@ import (
 
 	"topchain/x/subscription/types"
 
+	query "github.com/cosmos/cosmos-sdk/types/query"
+
 	keepertest "topchain/testutil/keeper"
 )
 
@@ -50,5 +52,35 @@ func TestSubscriptions(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, res.Subscriptions, 2)
 	require.Contains(t, res.Subscriptions, subscription1)
+	require.Contains(t, res.Subscriptions, subscription2)
+}
+
+func TestSubscriptionsWithPaginationOne(t *testing.T) {
+	keeper, ctx := keepertest.SubscriptionKeeper(t)
+	subscription1 := types.Subscription{
+		Id:       "sub1",
+		Provider: "provider1",
+	}
+	subscription2 := types.Subscription{
+		Id:       "sub2",
+		Provider: "provider1",
+	}
+	subscription3 := types.Subscription{
+		Id:       "sub3",
+		Provider: "provider2",
+	}
+
+	keeper.SetSubscription(ctx, subscription1)
+	keeper.SetSubscription(ctx, subscription2)
+	keeper.SetSubscription(ctx, subscription3)
+
+	req := &types.QuerySubscriptionsRequest{Provider: "provider1", Pagination: &query.PageRequest{Limit: 1}}
+	res, err := keeper.Subscriptions(ctx, req)
+	require.NoError(t, err)
+	require.Len(t, res.Subscriptions, 1)
+	require.Contains(t, res.Subscriptions, subscription1)
+	req = &types.QuerySubscriptionsRequest{Provider: "provider1", Pagination: &query.PageRequest{Key: res.Pagination.NextKey, Limit: 1}}
+	res, err = keeper.Subscriptions(ctx, req)
+	require.Len(t, res.Subscriptions, 1)
 	require.Contains(t, res.Subscriptions, subscription2)
 }

--- a/x/subscription/types/keys.go
+++ b/x/subscription/types/keys.go
@@ -12,7 +12,7 @@ const (
 
 	DealKeyPrefix                 = "Deal/value"
 	SubscriptionKeyPrefix         = "Subscription/value"
-	ProviderSubscriptionKeyPrefix = "Provider/Subscription/value"
+	SubscriptionProviderKeyPrefix = "Subscription/Provider/value"
 )
 
 var (

--- a/x/subscription/types/keys.go
+++ b/x/subscription/types/keys.go
@@ -10,8 +10,9 @@ const (
 	// MemStoreKey defines the in-memory store key
 	MemStoreKey = "mem_subscription"
 
-	DealKeyPrefix         = "Deal/value"
-	SubscriptionKeyPrefix = "Subscription/value"
+	DealKeyPrefix                 = "Deal/value"
+	SubscriptionKeyPrefix         = "Subscription/value"
+	ProviderSubscriptionKeyPrefix = "Provider/Subscription/value"
 )
 
 var (

--- a/x/subscription/types/keys.go
+++ b/x/subscription/types/keys.go
@@ -22,3 +22,8 @@ var (
 func KeyPrefix(p string) []byte {
 	return []byte(p)
 }
+
+// GetProviderStoreKey returns the key for the provider store for the given provider.
+func GetProviderStoreKey(provider string) []byte {
+	return []byte(KeyPrefix(SubscriptionProviderKeyPrefix + "/" + provider))
+}


### PR DESCRIPTION
Hey 👋 ,

This PR aim to fix #8.
I wasn't sure wherever or not a subscription could be set twice this is why I go with a map to be sure all subscription are unique. If this isn't the case we could go with a slice and it will make the subscription retrieval even easier.
Also would you like the `SetSubscription` to be divided like so:
```go
func (k Keeper) SetSubscription(ctx sdk.Context, subscription types.Subscription) {
	k.setSubscription(ctx, subscription)
	k.setProviderSubscription(ctx, subscription)
}

func (k Keeper) setSubscription(ctx sdk.Context, subscription types.Subscription) {
	storeAdapter := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
	store := prefix.NewStore(storeAdapter, types.KeyPrefix(types.SubscriptionKeyPrefix))

	appendedValue := k.cdc.MustMarshal(&subscription)
	store.Set([]byte(subscription.Id), appendedValue)
}

func (k Keeper) setProviderSubscription(ctx sdk.Context, subscription types.Subscription) {
	storeAdapter := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
	store := prefix.NewStore(storeAdapter, types.KeyPrefix(types.ProviderSubscriptionKeyPrefix))

	providerSubscriptionsBytes := store.Get([]byte(subscription.Provider))
	var providerSubscriptions types.SubscriptionMap
	if providerSubscriptionsBytes != nil {
		k.cdc.MustUnmarshal(providerSubscriptionsBytes, &providerSubscriptions)
	} else {
		providerSubscriptions = types.SubscriptionMap{Subscriptions: map[string]types.Subscription{}}
	}
	providerSubscriptions.Subscriptions[subscription.Id] = subscription
	mapValue := k.cdc.MustMarshal(&providerSubscriptions)
	store.Set([]byte(subscription.Provider), mapValue)
}
```
Or like so:
```go
func (k Keeper) SetSubscription(ctx sdk.Context, subscription types.Subscription) {
	storeAdapter := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
	k.setSubscription(storeAdapter, subscription)
	k.setProviderSubscription(storeAdapter, subscription)
}

func (k Keeper) setSubscription(storeAdapter storetypes.KVStore, subscription types.Subscription) {
	store := prefix.NewStore(storeAdapter, types.KeyPrefix(types.SubscriptionKeyPrefix))

	appendedValue := k.cdc.MustMarshal(&subscription)
	store.Set([]byte(subscription.Id), appendedValue)
}

func (k Keeper) setProviderSubscription(storeAdapter storetypes.KVStore, subscription types.Subscription) {
	store := prefix.NewStore(storeAdapter, types.KeyPrefix(types.ProviderSubscriptionKeyPrefix))

	providerSubscriptionsBytes := store.Get([]byte(subscription.Provider))
	var providerSubscriptions types.SubscriptionMap
	if providerSubscriptionsBytes != nil {
		k.cdc.MustUnmarshal(providerSubscriptionsBytes, &providerSubscriptions)
	} else {
		providerSubscriptions = types.SubscriptionMap{Subscriptions: map[string]types.Subscription{}}
	}
	providerSubscriptions.Subscriptions[subscription.Id] = subscription
	mapValue := k.cdc.MustMarshal(&providerSubscriptions)
	store.Set([]byte(subscription.Provider), mapValue)
}
```
Let me know thanks.

