### PR TITLE
feat(deal): add secondary mapping for requester

### DIFF
--- a/x/subscription/keeper/deal.go
+++ b/x/subscription/keeper/deal.go
@@ -14,6 +14,9 @@ func (k Keeper) SetDeal(ctx sdk.Context, deal types.Deal) {
 
 	appendedValue := k.cdc.MustMarshal(&deal)
 	store.Set([]byte(deal.Id), appendedValue)
+
+	providerStore := prefix.NewStore(storeAdapter, types.GetRequesterStoreKey(deal.Requester))
+	providerStore.Set([]byte(deal.Id), appendedValue)
 }
 
 func (k Keeper) GetDeal(ctx sdk.Context, dealId string) (deal types.Deal, found bool) {

--- a/x/subscription/keeper/query_deal.go
+++ b/x/subscription/keeper/query_deal.go
@@ -2,32 +2,66 @@ package keeper
 
 import (
 	"context"
+
 	"topchain/x/subscription/types"
 
+	"cosmossdk.io/store/prefix"
+	"github.com/cosmos/cosmos-sdk/runtime"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/cosmos/cosmos-sdk/types/query"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
-func (k Keeper) Deal(ctx context.Context, req *types.QueryDealRequest) (*types.QueryDealResponse, error) {
+func (k Keeper) Deal(goCtx context.Context, req *types.QueryDealRequest) (*types.QueryDealResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "invalid request")
 	}
+	ctx := sdk.UnwrapSDKContext(goCtx)
+	deal, found := k.GetDeal(ctx, req.Id)
+	if !found {
+		return nil, sdkerrors.ErrKeyNotFound
+	}
 
-	return &types.QueryDealResponse{}, nil
+	return &types.QueryDealResponse{Deal: deal}, nil
 }
 
-func (k Keeper) DealStatus(ctx context.Context, req *types.QueryDealStatusRequest) (*types.QueryDealStatusResponse, error) {
+func (k Keeper) DealStatus(goCtx context.Context, req *types.QueryDealStatusRequest) (*types.QueryDealStatusResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "invalid request")
 	}
+	ctx := sdk.UnwrapSDKContext(goCtx)
+	deal, found := k.GetDeal(ctx, req.Id)
+	if !found {
+		return nil, sdkerrors.ErrKeyNotFound
+	}
 
-	return &types.QueryDealStatusResponse{}, nil
+	return &types.QueryDealStatusResponse{Status: deal.Status}, nil
 }
 
-func (k Keeper) Deals(ctx context.Context, req *types.QueryDealsRequest) (*types.QueryDealsResponse, error) {
+func (k Keeper) Deals(goCtx context.Context, req *types.QueryDealsRequest) (*types.QueryDealsResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "invalid request")
 	}
 
-	return &types.QueryDealsResponse{}, nil
+	ctx := sdk.UnwrapSDKContext(goCtx)
+	storeAdapter := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
+	store := prefix.NewStore(storeAdapter, types.GetRequesterStoreKey(req.Requester))
+
+	var deals []types.Deal
+	pageRes, err := query.Paginate(store, req.Pagination, func(key []byte, value []byte) error {
+		var deal types.Deal
+		if err := k.cdc.Unmarshal(value, &deal); err != nil {
+			return err
+		}
+
+		deals = append(deals, deal)
+		return nil
+	})
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
+	return &types.QueryDealsResponse{Deals: deals, Pagination: pageRes}, nil
 }

--- a/x/subscription/keeper/query_deal_test.go
+++ b/x/subscription/keeper/query_deal_test.go
@@ -1,0 +1,85 @@
+package keeper_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	query "github.com/cosmos/cosmos-sdk/types/query"
+
+	keepertest "topchain/testutil/keeper"
+	"topchain/x/subscription/types"
+)
+
+func TestDeal(t *testing.T) {
+	keeper, ctx := keepertest.SubscriptionKeeper(t)
+	deal := types.Deal{
+		Id:        "deal1",
+		Requester: "Requester1",
+	}
+
+	keeper.SetDeal(ctx, deal)
+
+	req := &types.QueryDealRequest{Id: "deal1"}
+
+	retrievedDeal, err := keeper.Deal(ctx, req)
+	require.NoError(t, err)
+	require.Equal(t, deal, retrievedDeal.Deal)
+}
+
+func TestDeals(t *testing.T) {
+	keeper, ctx := keepertest.SubscriptionKeeper(t)
+	deal1 := types.Deal{
+		Id:        "deal1",
+		Requester: "Requester1",
+	}
+	deal2 := types.Deal{
+		Id:        "deal2",
+		Requester: "Requester1",
+	}
+	deal3 := types.Deal{
+		Id:        "deal3",
+		Requester: "Requester2",
+	}
+
+	keeper.SetDeal(ctx, deal1)
+	keeper.SetDeal(ctx, deal2)
+	keeper.SetDeal(ctx, deal3)
+
+	req := &types.QueryDealsRequest{Requester: "Requester1"}
+	res, err := keeper.Deals(ctx, req)
+	require.NoError(t, err)
+	require.Len(t, res.Deals, 2)
+	require.Contains(t, res.Deals, deal1)
+	require.Contains(t, res.Deals, deal2)
+}
+
+func TestDealsWithPaginationOne(t *testing.T) {
+	keeper, ctx := keepertest.SubscriptionKeeper(t)
+	deal1 := types.Deal{
+		Id:        "deal1",
+		Requester: "Requester1",
+	}
+	deal2 := types.Deal{
+		Id:        "deal2",
+		Requester: "Requester1",
+	}
+	deal3 := types.Deal{
+		Id:        "deal3",
+		Requester: "Requester2",
+	}
+
+	keeper.SetDeal(ctx, deal1)
+	keeper.SetDeal(ctx, deal2)
+	keeper.SetDeal(ctx, deal3)
+
+	req := &types.QueryDealsRequest{Requester: "Requester1", Pagination: &query.PageRequest{Limit: 1}}
+	res, err := keeper.Deals(ctx, req)
+	require.NoError(t, err)
+	require.Len(t, res.Deals, 1)
+	require.Contains(t, res.Deals, deal1)
+	req = &types.QueryDealsRequest{Requester: "Requester1", Pagination: &query.PageRequest{Key: res.Pagination.NextKey, Limit: 1}}
+	res, err = keeper.Deals(ctx, req)
+	require.Len(t, res.Deals, 1)
+	require.Contains(t, res.Deals, deal2)
+}

--- a/x/subscription/types/keys.go
+++ b/x/subscription/types/keys.go
@@ -10,12 +10,18 @@ const (
 	// MemStoreKey defines the in-memory store key
 	MemStoreKey = "mem_subscription"
 
-	DealKeyPrefix         = "Deal/value"
-	SubscriptionKeyPrefix = "Subscription/value"
+	DealKeyPrefix          = "Deal/value"
+	DealRequesterKeyPrefix = "Deal/Requester/value"
+	SubscriptionKeyPrefix  = "Subscription/value"
 )
 
 var ParamsKey = []byte("p_subscription")
 
 func KeyPrefix(p string) []byte {
 	return []byte(p)
+}
+
+// GetRequesterStoreKey returns the key for the provider store for the given provider.
+func GetRequesterStoreKey(requester string) []byte {
+	return []byte(KeyPrefix(DealRequesterKeyPrefix + "/" + requester))
 }


### PR DESCRIPTION
address #16 
As a note the testutil.SubscritpionKeeper need an update, in order to run mine as it was enough I've just made that:
```go
	k := keeper.NewKeeper(
		cdc,
		runtime.NewKVStoreService(storeKey),
		log.NewNopLogger(),
		authority.String(),
		"",
		nil,
		nil,
		nil,
	)
```
